### PR TITLE
feat: scaffold monorepo with api and web packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+pnpm-lock.yaml
+dist

--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  env: { node: true, es2020: true },
+  parser: '@typescript-eslint/parser',
+  parserOptions: { sourceType: 'module' },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended']
+};

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "api",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "postinstall": "prisma generate"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.14.0",
+    "fastify": "^4.27.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "eslint": "^8.57.0",
+    "prisma": "^5.14.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.5.0"
+  }
+}

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,0 +1,47 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id    String  @id @default(uuid())
+  email String  @unique
+  spots Spot[]
+}
+
+model Spot {
+  id          String       @id @default(uuid())
+  name        String
+  description String?
+  location    Unsupported("geometry(Point, 4326)")
+  photos      SpotPhoto[]
+  tags        SpotTag[]
+  user        User?        @relation(fields: [userId], references: [id])
+  userId      String?
+}
+
+model SpotPhoto {
+  id     String @id @default(uuid())
+  url    String
+  spot   Spot   @relation(fields: [spotId], references: [id])
+  spotId String
+}
+
+model Tag {
+  id    String   @id @default(uuid())
+  name  String   @unique
+  spots SpotTag[]
+}
+
+model SpotTag {
+  spot   Spot @relation(fields: [spotId], references: [id])
+  spotId String
+  tag    Tag  @relation(fields: [tagId], references: [id])
+  tagId  String
+
+  @@id([spotId, tagId])
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,0 +1,11 @@
+import { buildServer } from './server';
+
+const app = buildServer();
+
+app.listen({ port: 3000 }, (err, address) => {
+  if (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+  app.log.info(`server listening on ${address}`);
+});

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,0 +1,13 @@
+import Fastify from 'fastify';
+import { PrismaClient } from '@prisma/client';
+
+export function buildServer() {
+  const app = Fastify();
+  // Initialize Prisma Client
+  const prisma = new PrismaClient();
+  app.decorate('prisma', prisma);
+
+  app.get('/', async () => ({ hello: 'world' }));
+
+  return app;
+}

--- a/api/test/root.test.ts
+++ b/api/test/root.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { buildServer } from '../src/server';
+
+describe('root route', () => {
+  it('returns hello', async () => {
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ hello: 'world' });
+  });
+});

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "test"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+services:
+  db:
+    image: postgis/postgis:15-3.3
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: greenmap
+    ports:
+      - '5432:5432'
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  minio:
+    image: minio/minio:latest
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    command: server /data --console-address ":9001"
+    ports:
+      - '9000:9000'
+      - '9001:9001'
+    volumes:
+      - minio_data:/data
+volumes:
+  db_data:
+  minio_data:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "neighbourhood-green-map",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["api", "web"],
+  "scripts": {
+    "lint": "pnpm -r lint",
+    "typecheck": "pnpm -r typecheck",
+    "test": "pnpm -r test"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'api'
+  - 'web'

--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  env: { browser: true, es2020: true },
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'next/core-web-vitals']
+};

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.14",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
+    "typescript": "^5.4.0",
+    "vitest": "^1.5.0"
+  }
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Home</div>;
+}

--- a/web/pages/spots/[id].tsx
+++ b/web/pages/spots/[id].tsx
@@ -1,0 +1,7 @@
+import { useRouter } from 'next/router';
+
+export default function SpotPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  return <div>Spot {id as string}</div>;
+}

--- a/web/pages/submit.tsx
+++ b/web/pages/submit.tsx
@@ -1,0 +1,3 @@
+export default function Submit() {
+  return <div>Submit a spot</div>;
+}

--- a/web/test/basic.test.ts
+++ b/web/test/basic.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('math', () => {
+  it('works', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "test"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up pnpm workspaces with `api` and `web` packages
- add Fastify server with Prisma models
- scaffold Next.js frontend with basic routes
- add Docker Compose for PostGIS and MinIO
- configure CI workflow for lint, typecheck and tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter api test`
- `pnpm --filter web test`


