### PR TITLE
chore: organize pnpm workspace

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: { sourceType: 'module' },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+};

--- a/api/.eslintrc.cjs
+++ b/api/.eslintrc.cjs
@@ -1,7 +1,4 @@
 module.exports = {
-  env: { node: true, es2020: true },
-  parser: '@typescript-eslint/parser',
-  parserOptions: { sourceType: 'module' },
-  plugins: ['@typescript-eslint'],
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended']
+  extends: ['../.eslintrc.cjs'],
+  env: { node: true }
 };

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,12 +1,7 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "outDir": "dist",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true
+    "outDir": "dist"
   },
   "include": ["src", "test"]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "neighbourhood-green-map",
   "private": true,
   "version": "0.1.0",
-  "workspaces": ["api", "web"],
+  "workspaces": [
+    "api",
+    "web",
+    "packages/*"
+  ],
   "scripts": {
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",

--- a/packages/config/.eslintrc.cjs
+++ b/packages/config/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs']
+};

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "config",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\"",
+    "typecheck": "tsc --noEmit",
+    "test": "echo \"no tests\""
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "eslint": "^8.57.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,1 @@
+export const config = {};

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/types/.eslintrc.cjs
+++ b/packages/types/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs']
+};

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "types",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\"",
+    "typecheck": "tsc --noEmit",
+    "test": "echo \"no tests\""
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "eslint": "^8.57.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,1 @@
+export type ExampleType = Record<string, unknown>;

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/ui/.eslintrc.cjs
+++ b/packages/ui/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ['../../.eslintrc.cjs'],
+  env: { browser: true }
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\"",
+    "typecheck": "tsc --noEmit",
+    "test": "echo \"no tests\""
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "eslint": "^8.57.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = () => null;

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'api'
   - 'web'
+  - 'packages/*'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  }
+}

--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,7 +1,5 @@
 module.exports = {
-  env: { browser: true, es2020: true },
-  parser: '@typescript-eslint/parser',
-  parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
-  plugins: ['@typescript-eslint'],
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'next/core-web-vitals']
+  extends: ['../.eslintrc.cjs', 'next/core-web-vitals'],
+  env: { browser: true },
+  parserOptions: { ecmaFeatures: { jsx: true } }
 };

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"
   },


### PR DESCRIPTION
## Summary
- add pnpm workspace packages for ui, config, and types
- centralize ESLint and TypeScript configuration

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


