### PR TITLE
feat: proxy spot routes to backend

### DIFF
--- a/web/app/api/spots/[id]/route.ts
+++ b/web/app/api/spots/[id]/route.ts
@@ -1,12 +1,26 @@
 import { NextResponse } from 'next/server';
 
-const spots = [
-  { id: '1', name: 'Central Park', lat: -33.8688, lng: 151.2093, description: 'A nice park' },
-  { id: '2', name: 'Hyde Park', lat: -33.869, lng: 151.211, description: 'Another park' },
-];
+/**
+ * Fetches a single spot from the Fastify backend.
+ *
+ * As with the collection route, query parameters from the incoming request are
+ * forwarded so that the backend can apply any additional filtering or logic.
+ */
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: 'NEXT_PUBLIC_API_URL is not configured' },
+      { status: 500 },
+    );
+  }
 
-export async function GET(_req: Request, { params }: { params: { id: string } }) {
-  const spot = spots.find((s) => s.id === params.id);
-  if (!spot) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  return NextResponse.json(spot);
+  const apiUrl = new URL(`/spots/${params.id}`, baseUrl);
+  const { search } = new URL(req.url);
+  apiUrl.search = search;
+
+  const res = await fetch(apiUrl.toString());
+  const data = await res.json();
+
+  return NextResponse.json(data, { status: res.status });
 }

--- a/web/app/api/spots/route.ts
+++ b/web/app/api/spots/route.ts
@@ -1,10 +1,30 @@
 import { NextResponse } from 'next/server';
 
-const spots = [
-  { id: '1', name: 'Central Park', lat: -33.8688, lng: 151.2093, description: 'A nice park' },
-  { id: '2', name: 'Hyde Park', lat: -33.869, lng: 151.211, description: 'Another park' },
-];
+/**
+ * Proxies requests for spots to the Fastify backend.
+ *
+ * The API base URL is read from NEXT_PUBLIC_API_URL so the same code can run
+ * both locally and in production. Any query parameters included in the incoming
+ * request (e.g. `radius`, `bbox`) are forwarded to the backend so it can handle
+ * geospatial filtering.
+ */
+export async function GET(req: Request) {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: 'NEXT_PUBLIC_API_URL is not configured' },
+      { status: 500 },
+    );
+  }
 
-export async function GET() {
-  return NextResponse.json(spots);
+  // Construct the backend URL and propagate any query parameters from the
+  // incoming request.
+  const apiUrl = new URL('/spots', baseUrl);
+  const { search } = new URL(req.url);
+  apiUrl.search = search;
+
+  const res = await fetch(apiUrl.toString());
+  const data = await res.json();
+
+  return NextResponse.json(data, { status: res.status });
 }


### PR DESCRIPTION
## Summary
- forward spot list API to Fastify backend with query support
- proxy single spot requests to backend

## Testing
- `pnpm lint` *(fails: @typescript-eslint/ban-ts-comment etc.)*
- `pnpm test` *(fails: Cannot find module 'tailwindcss')*
- `pnpm typecheck` *(fails: Property 'id' does not exist on type 'unknown')*


------
https://chatgpt.com/codex/tasks/task_e_68c58266df0c832992c3d25ca54511f9