### PR TITLE
Enhance spot querying and tagging

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -21,12 +21,18 @@ model Spot {
   name        String
   description String?
   location    Unsupported("geometry(Point, 4326)")
+  facilities  Json         @default("{}")
+  category    SpotCategory
+  isPublished Boolean      @default(false)
   photos      SpotPhoto[]
   tags        SpotTag[]
+  votes       Vote[]
   user        User?        @relation(fields: [userId], references: [id])
   userId      String?
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+
+  @@index([location], type: Gist)
 }
 
 model SpotPhoto {
@@ -50,4 +56,25 @@ model SpotTag {
   tagId  String
 
   @@id([spotId, tagId])
+}
+
+model Vote {
+  user      User @relation(fields: [userId], references: [id])
+  userId    String
+  spot      Spot @relation(fields: [spotId], references: [id])
+  spotId    String
+  value     Int
+  createdAt DateTime @default(now())
+
+  @@id([userId, spotId])
+}
+
+enum SpotCategory {
+  park
+  garden
+  walk
+  lookout
+  playground
+  beach
+  other
 }


### PR DESCRIPTION
## Summary
- add facilities, category and published state to Spot schema with geospatial index and voting support
- extend `/spots` API with pagination, filtering and radius/bounding box lookup
- introduce tag management and spot voting endpoints

## Testing
- `npm test -w api` *(fails: vitest not found)*
- `npm run lint -w api` *(fails: ESLint configuration missing)*
- `npm run typecheck -w api` *(fails: missing @types/node and other type errors)*

