### PR TITLE
Integrate Fastify auth endpoints with JWT cookies

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@fastify/jwt": "^8.0.1",
+    "@fastify/cookie": "^9.0.0",
     "@fastify/redis": "^6.0.0",
     "@prisma/client": "^5.14.0",
     "bcryptjs": "^2.4.3",

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -12,6 +12,7 @@ model User {
   email        String   @unique
   passwordHash String
   spots        Spot[]
+  emailVerified Boolean  @default(false)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,6 +1,7 @@
 import Fastify, { FastifyReply, FastifyRequest } from 'fastify';
 import fastifyJwt from '@fastify/jwt';
 import fastifyRedis from '@fastify/redis';
+import fastifyCookie from '@fastify/cookie';
 import { PrismaClient, Spot } from '@prisma/client';
 import { ZodTypeProvider, serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
 import { z } from 'zod';
@@ -17,6 +18,7 @@ export function buildServer() {
   app.register(fastifyJwt, {
     secret: process.env.JWT_SECRET || 'supersecret',
   });
+  app.register(fastifyCookie);
   if (process.env.NODE_ENV !== 'test') {
     app.register(fastifyRedis, {
       url: process.env.REDIS_URL || 'redis://localhost:6379',
@@ -46,15 +48,18 @@ export function buildServer() {
         password: z.string().min(6),
       }),
       response: {
-        200: z.object({ token: z.string() }),
+        200: z.object({ token: z.string(), verificationToken: z.string().optional() }),
       },
     },
-  }, async (req) => {
+  }, async (req, reply) => {
     const { email, password } = req.body;
     const passwordHash = await bcrypt.hash(password, 10);
     const user = await prisma.user.create({ data: { email, passwordHash } });
     const token = app.jwt.sign({ id: user.id, email: user.email });
-    return { token };
+    reply.setCookie('token', token, { httpOnly: true, path: '/' });
+    const verificationToken = crypto.randomUUID();
+    await (app.redis as any)?.set(`verify:${verificationToken}`, user.id, { EX: 60 * 60 });
+    return { token, verificationToken };
   });
 
   app.post('/login', {
@@ -74,8 +79,61 @@ export function buildServer() {
     if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
       return reply.status(401).send({ message: 'Invalid credentials' });
     }
+    if (!user.emailVerified) {
+      return reply.status(401).send({ message: 'Email not verified' });
+    }
     const token = app.jwt.sign({ id: user.id, email: user.email });
+    reply.setCookie('token', token, { httpOnly: true, path: '/' });
     return { token };
+  });
+
+  app.post('/verify-email', {
+    schema: {
+      body: z.object({ token: z.string() }),
+      response: {
+        200: z.object({ success: z.boolean() }),
+      },
+    },
+  }, async (req, reply) => {
+    const { token } = req.body;
+    const userId = await (app.redis as any)?.get(`verify:${token}`);
+    if (!userId) {
+      return reply.status(400).send({ success: false });
+    }
+    await prisma.user.update({ where: { id: userId }, data: { emailVerified: true } });
+    await (app.redis as any)?.del(`verify:${token}`);
+    return { success: true };
+  });
+
+  app.post('/request-password-reset', {
+    schema: {
+      body: z.object({ email: z.string().email() }),
+      response: { 200: z.object({ resetToken: z.string().optional() }) },
+    },
+  }, async (req) => {
+    const { email } = req.body;
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) return { resetToken: undefined };
+    const token = crypto.randomUUID();
+    await (app.redis as any)?.set(`reset:${token}`, user.id, { EX: 60 * 60 });
+    return { resetToken: token };
+  });
+
+  app.post('/reset-password', {
+    schema: {
+      body: z.object({ token: z.string(), password: z.string().min(6) }),
+      response: { 200: z.object({ success: z.boolean() }) },
+    },
+  }, async (req, reply) => {
+    const { token, password } = req.body;
+    const userId = await (app.redis as any)?.get(`reset:${token}`);
+    if (!userId) {
+      return reply.status(400).send({ success: false });
+    }
+    const passwordHash = await bcrypt.hash(password, 10);
+    await prisma.user.update({ where: { id: userId }, data: { passwordHash } });
+    await (app.redis as any)?.del(`reset:${token}`);
+    return { success: true };
   });
 
   // Spot schema

--- a/web/app/api/auth/[...nextauth]/route.ts
+++ b/web/app/api/auth/[...nextauth]/route.ts
@@ -1,26 +1,46 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import NextAuth from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
+import jwt from 'jsonwebtoken';
+import { cookies } from 'next/headers';
+
+interface TokenPayload { id: string; email: string }
 
 const handler = NextAuth({
   providers: [
     Credentials({
-      name: 'Credentials',
-      credentials: {
-        username: { label: 'Username', type: 'text' },
-        password: { label: 'Password', type: 'password' },
-      },
-      async authorize(credentials) {
-        if (
-          credentials?.username === 'admin' &&
-          credentials.password === 'password'
-        ) {
-          return { id: '1', name: 'Admin' };
-        }
-        return null;
+      name: 'cookie',
+      credentials: {},
+      async authorize() {
+        const token = cookies().get('token');
+        if (!token) return null;
+        const decoded = jwt.decode(token.value) as TokenPayload | null;
+        if (!decoded) return null;
+        return { id: decoded.id, email: decoded.email };
       },
     }),
   ],
   session: { strategy: 'jwt' },
+  callbacks: {
+    async jwt({ token }) {
+      const cookie = cookies().get('token');
+      if (cookie) {
+        const decoded = jwt.decode(cookie.value) as TokenPayload | null;
+        if (decoded) {
+          (token as any).id = decoded.id;
+          (token as any).email = decoded.email;
+        }
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      const t = token as any;
+      if (t.id) {
+        (session as any).user = { id: t.id, email: t.email };
+      }
+      return session;
+    },
+  },
   secret: process.env.NEXTAUTH_SECRET,
 });
 

--- a/web/app/register/page.tsx
+++ b/web/app/register/page.tsx
@@ -4,20 +4,20 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Button from '../../components/ui/Button';
 
-export default function LoginPage() {
+export default function RegisterPage() {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/login`, {
+    await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password }),
       credentials: 'include',
     });
-    router.push('/');
+    router.push('/login');
   };
 
   return (
@@ -35,7 +35,7 @@ export default function LoginPage() {
         onChange={(e) => setPassword(e.target.value)}
         placeholder="Password"
       />
-      <Button type="submit" className="w-full">Sign In</Button>
+      <Button type="submit" className="w-full">Register</Button>
     </form>
   );
 }

--- a/web/app/request-password-reset/page.tsx
+++ b/web/app/request-password-reset/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+import Button from '../../components/ui/Button';
+
+export default function RequestPasswordResetPage() {
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/request-password-reset`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    setSent(true);
+  };
+
+  if (sent) {
+    return <p className="p-4 text-center">Check your email for a reset link.</p>;
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-4 max-w-sm mx-auto">
+      <input
+        className="border p-2 w-full"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+      />
+      <Button type="submit" className="w-full">Send Reset Link</Button>
+    </form>
+  );
+}

--- a/web/app/reset-password/page.tsx
+++ b/web/app/reset-password/page.tsx
@@ -1,41 +1,35 @@
 'use client';
 
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import Button from '../../components/ui/Button';
 
-export default function LoginPage() {
+export default function ResetPasswordPage() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
   const router = useRouter();
-  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/login`, {
+    await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/reset-password`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
-      credentials: 'include',
+      body: JSON.stringify({ token, password }),
     });
-    router.push('/');
+    router.push('/login');
   };
 
   return (
     <form onSubmit={handleSubmit} className="p-4 space-y-4 max-w-sm mx-auto">
       <input
-        className="border p-2 w-full"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="Email"
-      />
-      <input
         type="password"
         className="border p-2 w-full"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
-        placeholder="Password"
+        placeholder="New Password"
       />
-      <Button type="submit" className="w-full">Sign In</Button>
+      <Button type="submit" className="w-full">Reset Password</Button>
     </form>
   );
 }

--- a/web/app/verify-email/page.tsx
+++ b/web/app/verify-email/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export default function VerifyEmailPage() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+  const router = useRouter();
+  const [status, setStatus] = useState('Verifying...');
+
+  useEffect(() => {
+    if (!token) return;
+    fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/verify-email`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    })
+      .then(() => {
+        setStatus('Email verified');
+        router.push('/login');
+      })
+      .catch(() => setStatus('Verification failed'));
+  }, [token, router]);
+
+  return <p className="p-4 text-center">{status}</p>;
+}

--- a/web/components/Map.tsx
+++ b/web/components/Map.tsx
@@ -7,15 +7,14 @@ import { Spot } from '../lib/types';
 export default function Map({ spots }: { spots: Spot[] }) {
   return (
     <MapContainer
-      // @ts-ignore center is valid for MapContainer
+      // @ts-expect-error center is valid for MapContainer
       center={[-33.865143, 151.2099]}
-      // @ts-ignore zoom is valid for MapContainer
       zoom={12}
       className="h-full"
     >
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
       {spots.map((spot) => (
-        <Marker key={spot.id} position={[spot.lat, spot.lng] as any}>
+        <Marker key={spot.id} position={[spot.lat, spot.lng] as [number, number]}>
           <Popup>{spot.name}</Popup>
         </Marker>
       ))}

--- a/web/package.json
+++ b/web/package.json
@@ -16,11 +16,13 @@
     "@tanstack/react-query": "^5.29.0",
     "leaflet": "^1.9.4",
     "react-leaflet": "^4.2.1",
-    "next-auth": "^4.24.6"
+    "next-auth": "^4.24.6",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
     "@types/react": "^18.2.14",
+    "@types/jsonwebtoken": "^9.0.5",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.3",
     "typescript": "^5.4.0",


### PR DESCRIPTION
## Summary
- issue login and register tokens from Fastify API and store them in httpOnly cookies
- read JWT cookies in NextAuth to drive sessions
- add email verification and password reset flows with basic pages

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58267c09c8329ae2b25b2030484e0