### PR TITLE
feat: add presigned upload flow

### DIFF
--- a/web/app/api/spots/route.ts
+++ b/web/app/api/spots/route.ts
@@ -1,10 +1,20 @@
 import { NextResponse } from 'next/server';
 
-const spots = [
-  { id: '1', name: 'Central Park', lat: -33.8688, lng: 151.2093, description: 'A nice park' },
-  { id: '2', name: 'Hyde Park', lat: -33.869, lng: 151.211, description: 'Another park' },
-];
+const apiBase = process.env.API_URL || 'http://localhost:3001';
 
 export async function GET() {
-  return NextResponse.json(spots);
+  const res = await fetch(`${apiBase}/spots`);
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const res = await fetch(`${apiBase}/spots`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
 }

--- a/web/app/api/upload-url/route.ts
+++ b/web/app/api/upload-url/route.ts
@@ -1,7 +1,33 @@
 import { NextResponse } from 'next/server';
 
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const filename = searchParams.get('filename') ?? 'file';
-  return NextResponse.json({ url: `https://example.com/upload/${filename}` });
+  const type = searchParams.get('type') ?? '';
+  const size = Number(searchParams.get('size') ?? 0);
+
+  if (!ALLOWED_TYPES.includes(type)) {
+    return NextResponse.json({ error: 'Unsupported file type' }, { status: 400 });
+  }
+
+  if (size > MAX_SIZE) {
+    return NextResponse.json({ error: 'File too large' }, { status: 400 });
+  }
+
+  const apiBase = process.env.API_URL || 'http://localhost:3001';
+  const res = await fetch(`${apiBase}/uploads/presign`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ filename, contentType: type, size }),
+  });
+
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Failed to get upload URL' }, { status: res.status });
+  }
+
+  const data = await res.json();
+  return NextResponse.json(data);
 }

--- a/web/app/submit/page.tsx
+++ b/web/app/submit/page.tsx
@@ -3,16 +3,60 @@
 import { useState } from 'react';
 import Button from '../../components/ui/Button';
 
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+
 export default function SubmitPage() {
   const [file, setFile] = useState<File | null>(null);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!file) return;
-    const res = await fetch(`/api/upload-url?filename=${encodeURIComponent(file.name)}`);
-    const { url } = await res.json();
-    await fetch(url, { method: 'PUT', body: file });
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      alert('Unsupported file type');
+      return;
+    }
+    if (file.size > MAX_SIZE) {
+      alert('File is too large');
+      return;
+    }
+
+    const params = new URLSearchParams({
+      filename: file.name,
+      type: file.type,
+      size: file.size.toString(),
+    });
+    const res = await fetch(`/api/upload-url?${params.toString()}`);
+    if (!res.ok) {
+      alert('Failed to get upload URL');
+      return;
+    }
+    const { url, key } = await res.json();
+
+    const uploadRes = await fetch(url, {
+      method: 'PUT',
+      body: file,
+      headers: { 'Content-Type': file.type },
+    });
+    if (!uploadRes.ok) {
+      alert('Upload failed');
+      return;
+    }
+
+    await fetch('/api/spots', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Uploaded spot',
+        lat: 0,
+        lng: 0,
+        photos: [key],
+      }),
+    });
+
     alert('Uploaded');
   };
+
   return (
     <form onSubmit={handleSubmit} className="p-4 space-y-4">
       <input type="file" onChange={(e) => setFile(e.target.files?.[0] ?? null)} />


### PR DESCRIPTION
## Summary
- proxy API route to Fastify for presigned S3 uploads and validate file type/size
- proxy spots API and allow creating spots with uploaded key
- handle upload in submit page and send key when creating a spot

## Testing
- `pnpm lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore" in Map.tsx)*
- `pnpm typecheck` *(fails: Parameter 'url' implicitly has an 'any' type ...)*
- `pnpm test` *(fails: Cannot find module 'tailwindcss')*


------
https://chatgpt.com/codex/tasks/task_e_68c58268bd208329bc61d28ca82165a8