### PR TITLE
Add filter bar and query parameter support

### DIFF
--- a/web/app/api/spots/route.ts
+++ b/web/app/api/spots/route.ts
@@ -2,8 +2,15 @@ import { NextResponse } from 'next/server';
 
 const apiBase = process.env.API_URL || 'http://localhost:3001';
 
-export async function GET() {
-  const res = await fetch(`${apiBase}/spots`);
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const params = new URLSearchParams();
+  for (const key of ['bbox', 'radius', 'tags', 'q']) {
+    const value = url.searchParams.get(key);
+    if (value) params.set(key, value);
+  }
+  const query = params.toString();
+  const res = await fetch(`${apiBase}/spots${query ? `?${query}` : ''}`);
   const data = await res.json();
   return NextResponse.json(data, { status: res.status });
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,11 +1,38 @@
 'use client';
 
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Map from '../components/Map';
+import FilterBar, { FilterState } from '../components/FilterBar';
 import { fetchSpots } from '../lib/api';
 
 export default function HomePage() {
-  const { data } = useQuery({ queryKey: ['spots'], queryFn: fetchSpots });
+  const [filters, setFilters] = useState<FilterState>({
+    category: '',
+    tags: '',
+    radius: 1000,
+  });
+
+  const { data } = useQuery({
+    queryKey: ['spots', filters],
+    queryFn: () =>
+      fetchSpots({
+        radius: filters.radius,
+        tags: filters.tags
+          ? filters.tags.split(',').map((t) => t.trim()).filter(Boolean)
+          : undefined,
+        q: filters.category || undefined,
+      }),
+  });
+
   if (!data) return <div className="p-4">Loading...</div>;
-  return <div className="h-full"> <Map spots={data} /> </div>;
+
+  return (
+    <div className="h-full flex flex-col">
+      <FilterBar filters={filters} onChange={setFilters} />
+      <div className="flex-1">
+        <Map spots={data} />
+      </div>
+    </div>
+  );
 }

--- a/web/components/FilterBar.tsx
+++ b/web/components/FilterBar.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React from 'react';
+
+export interface FilterState {
+  category: string;
+  tags: string;
+  radius: number;
+}
+
+export default function FilterBar({
+  filters,
+  onChange,
+}: {
+  filters: FilterState;
+  onChange: (filters: FilterState) => void;
+}) {
+  const handleChange = (key: keyof FilterState, value: string | number) => {
+    onChange({ ...filters, [key]: value });
+  };
+
+  return (
+    <div className="flex gap-2 p-2 bg-white shadow z-[1000]">
+      <select
+        className="border p-1"
+        value={filters.category}
+        onChange={(e) => handleChange('category', e.target.value)}
+      >
+        <option value="">All Categories</option>
+        <option value="park">Park</option>
+        <option value="garden">Garden</option>
+        <option value="community">Community</option>
+      </select>
+      <input
+        type="text"
+        className="border p-1"
+        placeholder="Tags (comma separated)"
+        value={filters.tags}
+        onChange={(e) => handleChange('tags', e.target.value)}
+      />
+      <input
+        type="number"
+        className="border p-1 w-24"
+        placeholder="Radius (m)"
+        value={filters.radius}
+        onChange={(e) => handleChange('radius', Number(e.target.value))}
+      />
+    </div>
+  );
+}
+

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,7 +1,21 @@
 import { Spot } from './types';
 
-export async function fetchSpots(): Promise<Spot[]> {
-  const res = await fetch('/api/spots');
+export interface SpotFilters {
+  bbox?: string;
+  radius?: number;
+  tags?: string[];
+  q?: string;
+}
+
+export async function fetchSpots(filters: SpotFilters = {}): Promise<Spot[]> {
+  const params = new URLSearchParams();
+  if (filters.bbox) params.set('bbox', filters.bbox);
+  if (typeof filters.radius === 'number') params.set('radius', String(filters.radius));
+  if (filters.tags && filters.tags.length > 0) params.set('tags', filters.tags.join(','));
+  if (filters.q) params.set('q', filters.q);
+
+  const query = params.toString();
+  const res = await fetch(`/api/spots${query ? `?${query}` : ''}`);
   if (!res.ok) throw new Error('Failed to fetch spots');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add filter bar with category, tag and radius options
- forward bbox, radius, tags and q query params to backend
- reload map markers via TanStack Query when filters change

## Testing
- `pnpm lint` *(fails: api package lint errors)*
- `pnpm typecheck` *(fails: missing @fastify/cookie and other api issues)*
- `pnpm test` *(fails: missing jsdom dependency)*

