### PR TITLE
feat: add moderation system

### DIFF
--- a/api/prisma/migrations/20231010120000_init/migration.sql
+++ b/api/prisma/migrations/20231010120000_init/migration.sql
@@ -1,0 +1,136 @@
+-- CreateEnum
+CREATE TYPE "SpotCategory" AS ENUM ('park', 'garden', 'walk', 'lookout', 'playground', 'beach', 'other');
+
+-- CreateEnum
+CREATE TYPE "UserRole" AS ENUM ('user', 'admin');
+
+-- CreateEnum
+CREATE TYPE "ReportStatus" AS ENUM ('pending', 'approved', 'rejected');
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "role" "UserRole" NOT NULL DEFAULT 'user',
+    "emailVerified" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Spot" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "location" geometry(Point, 4326) NOT NULL,
+    "facilities" JSONB NOT NULL DEFAULT '{}',
+    "category" "SpotCategory" NOT NULL,
+    "isPublished" BOOLEAN NOT NULL DEFAULT false,
+    "userId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Spot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SpotPhoto" (
+    "id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "spotId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SpotPhoto_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Tag" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SpotTag" (
+    "spotId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+
+    CONSTRAINT "SpotTag_pkey" PRIMARY KEY ("spotId","tagId")
+);
+
+-- CreateTable
+CREATE TABLE "Vote" (
+    "userId" TEXT NOT NULL,
+    "spotId" TEXT NOT NULL,
+    "value" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Vote_pkey" PRIMARY KEY ("userId","spotId")
+);
+
+-- CreateTable
+CREATE TABLE "Report" (
+    "id" TEXT NOT NULL,
+    "spotId" TEXT NOT NULL,
+    "userId" TEXT,
+    "reason" TEXT NOT NULL,
+    "status" "ReportStatus" NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Report_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL,
+    "reportId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE INDEX "Spot_location_idx" ON "Spot" USING GIST ("location");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_name_key" ON "Tag"("name");
+
+-- AddForeignKey
+ALTER TABLE "Spot" ADD CONSTRAINT "Spot_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SpotPhoto" ADD CONSTRAINT "SpotPhoto_spotId_fkey" FOREIGN KEY ("spotId") REFERENCES "Spot"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SpotTag" ADD CONSTRAINT "SpotTag_spotId_fkey" FOREIGN KEY ("spotId") REFERENCES "Spot"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SpotTag" ADD CONSTRAINT "SpotTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Vote" ADD CONSTRAINT "Vote_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Vote" ADD CONSTRAINT "Vote_spotId_fkey" FOREIGN KEY ("spotId") REFERENCES "Spot"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Report" ADD CONSTRAINT "Report_spotId_fkey" FOREIGN KEY ("spotId") REFERENCES "Spot"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Report" ADD CONSTRAINT "Report_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_reportId_fkey" FOREIGN KEY ("reportId") REFERENCES "Report"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLog" ADD CONSTRAINT "AuditLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/api/prisma/migrations/migration_lock.toml
+++ b/api/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma Migrate lockfile
+provider = "postgresql"

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -11,7 +11,11 @@ model User {
   id           String   @id @default(uuid())
   email        String   @unique
   passwordHash String
+  role         UserRole @default(user)
   spots        Spot[]
+  reports      Report[]
+  auditLogs    AuditLog[]
+  votes        Vote[]
   emailVerified Boolean  @default(false)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
@@ -28,6 +32,7 @@ model Spot {
   photos      SpotPhoto[]
   tags        SpotTag[]
   votes       Vote[]
+  reports     Report[]
   user        User?        @relation(fields: [userId], references: [id])
   userId      String?
   createdAt   DateTime     @default(now())
@@ -70,6 +75,28 @@ model Vote {
   @@id([userId, spotId])
 }
 
+model Report {
+  id        String       @id @default(uuid())
+  spot      Spot         @relation(fields: [spotId], references: [id])
+  spotId    String
+  user      User?        @relation(fields: [userId], references: [id])
+  userId    String?
+  reason    String
+  status    ReportStatus @default(pending)
+  createdAt DateTime     @default(now())
+  auditLogs AuditLog[]
+}
+
+model AuditLog {
+  id        String   @id @default(uuid())
+  report    Report   @relation(fields: [reportId], references: [id])
+  reportId  String
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  action    String
+  createdAt DateTime @default(now())
+}
+
 enum SpotCategory {
   park
   garden
@@ -78,4 +105,15 @@ enum SpotCategory {
   playground
   beach
   other
+}
+
+enum UserRole {
+  user
+  admin
+}
+
+enum ReportStatus {
+  pending
+  approved
+  rejected
 }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -2,12 +2,18 @@ import Fastify, { FastifyReply, FastifyRequest } from 'fastify';
 import fastifyJwt from '@fastify/jwt';
 import fastifyRedis from '@fastify/redis';
 import fastifyCookie from '@fastify/cookie';
-import { PrismaClient, Spot } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
 
 import { ZodTypeProvider, serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import crypto from 'node:crypto';
+
+type RedisClient = {
+  set: (key: string, value: string, opts: { EX: number }) => Promise<unknown>;
+  get: (key: string) => Promise<string | null>;
+  del: (key: string) => Promise<unknown>;
+};
 
 export function buildServer() {
   const app = Fastify().withTypeProvider<ZodTypeProvider>();
@@ -39,6 +45,13 @@ export function buildServer() {
     }
   });
 
+  app.decorate('adminOnly', async function (request: FastifyRequest, reply: FastifyReply) {
+    const user = await prisma.user.findUnique({ where: { id: request.user.id } });
+    if (user?.role !== 'admin') {
+      reply.status(403).send({ message: 'Forbidden' });
+    }
+  });
+
   app.get('/', async () => ({ hello: 'world' }));
 
   // Auth routes
@@ -59,7 +72,7 @@ export function buildServer() {
     const token = app.jwt.sign({ id: user.id, email: user.email });
     reply.setCookie('token', token, { httpOnly: true, path: '/' });
     const verificationToken = crypto.randomUUID();
-    await (app.redis as any)?.set(`verify:${verificationToken}`, user.id, { EX: 60 * 60 });
+    await (app.redis as unknown as RedisClient | undefined)?.set(`verify:${verificationToken}`, user.id, { EX: 60 * 60 });
     return { token, verificationToken };
   });
 
@@ -97,12 +110,12 @@ export function buildServer() {
     },
   }, async (req, reply) => {
     const { token } = req.body;
-    const userId = await (app.redis as any)?.get(`verify:${token}`);
+    const userId = await (app.redis as unknown as RedisClient | undefined)?.get(`verify:${token}`);
     if (!userId) {
       return reply.status(400).send({ success: false });
     }
     await prisma.user.update({ where: { id: userId }, data: { emailVerified: true } });
-    await (app.redis as any)?.del(`verify:${token}`);
+    await (app.redis as unknown as RedisClient | undefined)?.del(`verify:${token}`);
     return { success: true };
   });
 
@@ -116,7 +129,7 @@ export function buildServer() {
     const user = await prisma.user.findUnique({ where: { email } });
     if (!user) return { resetToken: undefined };
     const token = crypto.randomUUID();
-    await (app.redis as any)?.set(`reset:${token}`, user.id, { EX: 60 * 60 });
+    await (app.redis as unknown as RedisClient | undefined)?.set(`reset:${token}`, user.id, { EX: 60 * 60 });
     return { resetToken: token };
   });
 
@@ -127,13 +140,13 @@ export function buildServer() {
     },
   }, async (req, reply) => {
     const { token, password } = req.body;
-    const userId = await (app.redis as any)?.get(`reset:${token}`);
+    const userId = await (app.redis as unknown as RedisClient | undefined)?.get(`reset:${token}`);
     if (!userId) {
       return reply.status(400).send({ success: false });
     }
     const passwordHash = await bcrypt.hash(password, 10);
     await prisma.user.update({ where: { id: userId }, data: { passwordHash } });
-    await (app.redis as any)?.del(`reset:${token}`);
+    await (app.redis as unknown as RedisClient | undefined)?.del(`reset:${token}`);
     return { success: true };
   });
 
@@ -225,7 +238,7 @@ export function buildServer() {
       `;
     }
 
-    const where: any = {};
+    const where: Record<string, unknown> = {};
     if (ids) where.id = { in: ids.map((r) => r.id) };
     if (q) where.name = { contains: q, mode: 'insensitive' };
     if (tags) {
@@ -315,6 +328,38 @@ export function buildServer() {
     return { score: total._sum.value ?? 0 };
   });
 
+  app.get('/reports', {
+    preHandler: [app.authenticate, app.adminOnly],
+  }, async () => {
+    return prisma.report.findMany({ include: { spot: true } });
+  });
+
+  app.get('/moderation/queue', {
+    preHandler: [app.authenticate, app.adminOnly],
+  }, async () => {
+    return prisma.report.findMany({ where: { status: 'pending' }, include: { spot: true } });
+  });
+
+  app.post('/reports/:id', {
+    preHandler: [app.authenticate, app.adminOnly],
+    schema: {
+      params: z.object({ id: z.string().uuid() }),
+      body: z.object({ action: z.enum(['approve', 'reject']) }),
+    },
+  }, async (req) => {
+    const { id } = req.params;
+    const { action } = req.body;
+    const status = action === 'approve' ? 'approved' : 'rejected';
+    const report = await prisma.report.update({ where: { id }, data: { status }, include: { spot: true } });
+    await prisma.auditLog.create({
+      data: { reportId: report.id, userId: req.user.id, action },
+    });
+    if (action === 'approve') {
+      await prisma.spot.update({ where: { id: report.spotId }, data: { isPublished: false } });
+    }
+    return report;
+  });
+
   return app;
 }
 
@@ -323,6 +368,7 @@ declare module 'fastify' {
   interface FastifyInstance {
     prisma: PrismaClient;
     authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    adminOnly: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
   }
 }
 

--- a/web/app/api/moderation/queue/route.ts
+++ b/web/app/api/moderation/queue/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+const apiBase = process.env.API_URL || 'http://localhost:3001';
+
+export async function GET() {
+  const res = await fetch(`${apiBase}/moderation/queue`, {
+    headers: { 'Content-Type': 'application/json' },
+    cache: 'no-store',
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/web/app/api/reports/[id]/route.ts
+++ b/web/app/api/reports/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+const apiBase = process.env.API_URL || 'http://localhost:3001';
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const body = await req.json();
+  const res = await fetch(`${apiBase}/reports/${params.id}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/web/app/moderation/page.tsx
+++ b/web/app/moderation/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Button from '../../components/ui/Button';
+import { fetchModerationQueue, resolveReport } from '../../lib/api';
+import type { Report } from '../../lib/types';
+
+export default function ModerationPage() {
+  const [reports, setReports] = useState<Report[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchModerationQueue()
+      .then(setReports)
+      .catch(() => setError('Unauthorized'));
+  }, []);
+
+  const handle = async (id: string, action: 'approve' | 'reject') => {
+    try {
+      await resolveReport(id, action);
+      setReports((prev) => prev.filter((r) => r.id !== id));
+    } catch {
+      alert('Action failed');
+    }
+  };
+
+  if (error) return <p>{error}</p>;
+
+  return (
+    <div className="p-4 space-y-4">
+      {reports.map((report) => (
+        <div key={report.id} className="border p-2 flex justify-between items-center">
+          <div>
+            <p className="font-bold">{report.spot.name}</p>
+            <p className="text-sm text-gray-600">{report.reason}</p>
+          </div>
+          <div className="space-x-2">
+            <Button onClick={() => handle(report.id, 'approve')}>Approve</Button>
+            <Button onClick={() => handle(report.id, 'reject')} className="bg-red-600">Reject</Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,4 +1,4 @@
-import { Spot } from './types';
+import { Spot, Report } from './types';
 
 export async function fetchSpots(): Promise<Spot[]> {
   const res = await fetch('/api/spots');
@@ -10,4 +10,19 @@ export async function fetchSpot(id: string): Promise<Spot> {
   const res = await fetch(`/api/spots/${id}`);
   if (!res.ok) throw new Error('Failed to fetch spot');
   return res.json();
+}
+
+export async function fetchModerationQueue(): Promise<Report[]> {
+  const res = await fetch('/api/moderation/queue');
+  if (!res.ok) throw new Error('Failed to fetch reports');
+  return res.json();
+}
+
+export async function resolveReport(id: string, action: 'approve' | 'reject'): Promise<void> {
+  const res = await fetch(`/api/reports/${id}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action }),
+  });
+  if (!res.ok) throw new Error('Failed to resolve report');
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -5,3 +5,12 @@ export interface Spot {
   lng: number;
   description: string;
 }
+
+export interface Report {
+  id: string;
+  reason: string;
+  spot: {
+    id: string;
+    name: string;
+  };
+}


### PR DESCRIPTION
## Summary
- add Report and AuditLog Prisma models and initial migration
- expose admin-only report moderation endpoints
- build moderation UI with approve/reject actions

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: fetch failed)*


