### PR TITLE
feat: add favourites feature

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -16,6 +16,7 @@ model User {
   reports      Report[]
   auditLogs    AuditLog[]
   votes        Vote[]
+  favourites   Favourite[]
 
   emailVerified Boolean  @default(false)
   createdAt    DateTime @default(now())
@@ -34,6 +35,7 @@ model Spot {
   tags        SpotTag[]
   votes       Vote[]
   reports     Report[]
+  favourites Favourite[]
 
   user        User?        @relation(fields: [userId], references: [id])
   userId      String?
@@ -72,6 +74,16 @@ model Vote {
   spot      Spot @relation(fields: [spotId], references: [id])
   spotId    String
   value     Int
+  createdAt DateTime @default(now())
+
+  @@id([userId, spotId])
+}
+
+model Favourite {
+  user   User @relation(fields: [userId], references: [id])
+  userId String
+  spot   Spot @relation(fields: [spotId], references: [id])
+  spotId String
   createdAt DateTime @default(now())
 
   @@id([userId, spotId])

--- a/web/app/me/page.tsx
+++ b/web/app/me/page.tsx
@@ -1,17 +1,31 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import { fetchFavourites } from '../../lib/api';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { fetchFavourites, removeFavourite } from '../../lib/api';
 
 export default function MePage() {
-  const { data } = useQuery({ queryKey: ['favourites'], queryFn: fetchFavourites });
-  if (!data) return <div className="p-4">Loading...</div>;
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useQuery({ queryKey: ['favourites'], queryFn: fetchFavourites });
+  const removeMutation = useMutation(removeFavourite, {
+    onSuccess: () => queryClient.invalidateQueries(['favourites']),
+  });
+
+  if (isLoading) return <div className="p-4">Loading...</div>;
   return (
     <div className="p-4 space-y-2">
       <h1 className="text-2xl font-bold">My Favourite Spots</h1>
-      <ul className="list-disc pl-5">
-        {data.map((spot) => (
-          <li key={spot.id}>{spot.name}</li>
+      <ul className="list-disc pl-5 space-y-1">
+        {data?.map((spot) => (
+          <li key={spot.id} className="flex items-center gap-2">
+            <span>{spot.name}</span>
+            <button
+              className="text-sm text-red-600"
+              onClick={() => removeMutation.mutate(spot.id)}
+              disabled={removeMutation.isLoading && removeMutation.variables === spot.id}
+            >
+              {removeMutation.isLoading && removeMutation.variables === spot.id ? 'Removing...' : 'Remove'}
+            </button>
+          </li>
         ))}
       </ul>
     </div>

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -42,3 +42,24 @@ export async function resolveReport(id: string, action: 'approve' | 'reject'): P
   if (!res.ok) throw new Error('Failed to resolve report');
 
 }
+
+export async function fetchFavourites(): Promise<Spot[]> {
+  const res = await fetch('/api/me/favourites');
+  if (!res.ok) throw new Error('Failed to fetch favourites');
+  return res.json();
+}
+
+export async function addFavourite(spotId: string): Promise<Spot> {
+  const res = await fetch('/api/me/favourites', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ spotId }),
+  });
+  if (!res.ok) throw new Error('Failed to add favourite');
+  return res.json();
+}
+
+export async function removeFavourite(spotId: string): Promise<void> {
+  const res = await fetch(`/api/me/favourites/${spotId}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to remove favourite');
+}


### PR DESCRIPTION
## Summary
- add Favourite model and Prisma relations
- expose authenticated `/me/favourites` routes for listing, adding and removing
- support favourite management in web client

## Testing
- `pnpm --filter api db:migrate` *(fails: Environment variable not found: DATABASE_URL)*
- `pnpm lint`
- `pnpm test` *(fails: api tests require database setup)*

