### PR TITLE
feat: add routes models and API helpers

### DIFF
--- a/api/prisma/migrations/20240622120000_add_route_models/migration.sql
+++ b/api/prisma/migrations/20240622120000_add_route_models/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "Route" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Route_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RouteSpot" (
+    "routeId" TEXT NOT NULL,
+    "spotId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    CONSTRAINT "RouteSpot_pkey" PRIMARY KEY ("routeId","spotId")
+);
+
+-- AddForeignKey
+ALTER TABLE "Route" ADD CONSTRAINT "Route_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RouteSpot" ADD CONSTRAINT "RouteSpot_routeId_fkey" FOREIGN KEY ("routeId") REFERENCES "Route"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RouteSpot" ADD CONSTRAINT "RouteSpot_spotId_fkey" FOREIGN KEY ("spotId") REFERENCES "Spot"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -16,6 +16,7 @@ model User {
   reports      Report[]
   auditLogs    AuditLog[]
   votes        Vote[]
+  routes       Route[]
 
   emailVerified Boolean  @default(false)
   createdAt    DateTime @default(now())
@@ -34,6 +35,7 @@ model Spot {
   tags        SpotTag[]
   votes       Vote[]
   reports     Report[]
+  routes      RouteSpot[]
 
   user        User?        @relation(fields: [userId], references: [id])
   userId      String?
@@ -98,6 +100,27 @@ model AuditLog {
   action    String
   createdAt DateTime @default(now())
 
+}
+
+model Route {
+  id          String       @id @default(uuid())
+  name        String
+  description String?
+  user        User         @relation(fields: [userId], references: [id])
+  userId      String
+  spots       RouteSpot[]
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+}
+
+model RouteSpot {
+  route   Route @relation(fields: [routeId], references: [id], onDelete: Cascade)
+  routeId String
+  spot    Spot  @relation(fields: [spotId], references: [id], onDelete: Cascade)
+  spotId  String
+  order   Int
+
+  @@id([routeId, spotId])
 }
 
 enum SpotCategory {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,4 +1,4 @@
-import { Spot, Report } from './types';
+import { Spot, Report, Route } from './types';
 
 
 export interface SpotFilters {
@@ -41,4 +41,47 @@ export async function resolveReport(id: string, action: 'approve' | 'reject'): P
   });
   if (!res.ok) throw new Error('Failed to resolve report');
 
+}
+
+export async function fetchRoutes(): Promise<Route[]> {
+  const res = await fetch('/api/routes');
+  if (!res.ok) throw new Error('Failed to fetch routes');
+  return res.json();
+}
+
+export async function fetchRoute(id: string): Promise<Route> {
+  const res = await fetch(`/api/routes/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch route');
+  return res.json();
+}
+
+export interface RouteInput {
+  name: string;
+  description?: string;
+  spotIds: string[];
+}
+
+export async function createRoute(data: RouteInput): Promise<Route> {
+  const res = await fetch('/api/routes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to create route');
+  return res.json();
+}
+
+export async function updateRoute(id: string, data: Partial<RouteInput>): Promise<Route> {
+  const res = await fetch(`/api/routes/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to update route');
+  return res.json();
+}
+
+export async function deleteRoute(id: string): Promise<void> {
+  const res = await fetch(`/api/routes/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to delete route');
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -15,3 +15,17 @@ export interface Report {
   };
 
 }
+
+export interface Route {
+  id: string;
+  name: string;
+  description?: string;
+  spots: RouteSpot[];
+}
+
+export interface RouteSpot {
+  routeId: string;
+  spotId: string;
+  order: number;
+  spot: Spot;
+}


### PR DESCRIPTION
## Summary
- add Route and RouteSpot Prisma models with migration
- expose route CRUD helpers for frontend
- define shared Route types for web

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config next/core-web-vitals)*
- `pnpm typecheck` *(fails: missing dependencies and type errors)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a0534f488329b343b1b4ff361523