### PR TITLE
feat(web): unify API base env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for local development
+NEXT_PUBLIC_API_URL=http://localhost:3001

--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ pnpm --filter web dev
 * `NODE_ENV`, `PORT`
 * `DATABASE_URL` (Postgres)
 * `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY` (PEM)
+* `NEXT_PUBLIC_API_URL` (frontend base URL for the API)
 * `COOKIE_DOMAIN`, `COOKIE_SECURE=true`
 * `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`
 * `MAPBOX_TOKEN`

--- a/web/app/api/me/favourites/[id]/route.ts
+++ b/web/app/api/me/favourites/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const apiBase = process.env.API_URL || 'http://localhost:3001';
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 export async function POST(_req: Request, { params }: { params: { id: string } }) {
   const res = await fetch(`${apiBase}/me/favourites/${params.id}`, { method: 'POST' });

--- a/web/app/api/me/favourites/route.ts
+++ b/web/app/api/me/favourites/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const apiBase = process.env.API_URL || 'http://localhost:3001';
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 export async function GET() {
   const res = await fetch(`${apiBase}/me/favourites`);

--- a/web/app/api/moderation/queue/route.ts
+++ b/web/app/api/moderation/queue/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const apiBase = process.env.API_URL || 'http://localhost:3001';
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 export async function GET() {
   const res = await fetch(`${apiBase}/moderation/queue`, {

--- a/web/app/api/reports/[id]/route.ts
+++ b/web/app/api/reports/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const apiBase = process.env.API_URL || 'http://localhost:3001';
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
   const body = await req.json();

--- a/web/app/api/routes/[id]/route.ts
+++ b/web/app/api/routes/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const apiBase = process.env.API_URL || 'http://localhost:3001';
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const res = await fetch(`${apiBase}/routes/${params.id}`);

--- a/web/app/api/routes/route.ts
+++ b/web/app/api/routes/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const apiBase = process.env.API_URL || 'http://localhost:3001';
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 export async function GET() {
   const res = await fetch(`${apiBase}/routes`);

--- a/web/app/api/spots/[id]/route.ts
+++ b/web/app/api/spots/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
 /**
  * Fetches a single spot from the Fastify backend.
  *
@@ -7,15 +9,7 @@ import { NextResponse } from 'next/server';
  * forwarded so that the backend can apply any additional filtering or logic.
  */
 export async function GET(req: Request, { params }: { params: { id: string } }) {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
-  if (!baseUrl) {
-    return NextResponse.json(
-      { error: 'NEXT_PUBLIC_API_URL is not configured' },
-      { status: 500 },
-    );
-  }
-
-  const apiUrl = new URL(`/spots/${params.id}`, baseUrl);
+  const apiUrl = new URL(`/spots/${params.id}`, apiBase);
   const { search } = new URL(req.url);
   apiUrl.search = search;
 

--- a/web/app/api/spots/route.ts
+++ b/web/app/api/spots/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-const apiBase = process.env.API_URL || 'http://localhost:3001';
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 export async function GET(req: Request) {
   const url = new URL(req.url);

--- a/web/app/api/upload-url/route.ts
+++ b/web/app/api/upload-url/route.ts
@@ -17,7 +17,7 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'File too large' }, { status: 400 });
   }
 
-  const apiBase = process.env.API_URL || 'http://localhost:3001';
+  const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
   const res = await fetch(`${apiBase}/uploads/presign`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- expose Fastify base URL via `NEXT_PUBLIC_API_URL`
- reference `NEXT_PUBLIC_API_URL` in all Next.js API routes
- document `NEXT_PUBLIC_API_URL` in README and `.env.example`

## Testing
- `pnpm --filter web lint`
- `pnpm --filter web typecheck` *(fails: Module '../../lib/api' has no exported member 'fetchFavourites', property 'map' does not exist on type '{}', etc.)*
- `pnpm --filter web test` *(fails: fetch failed, ECONNREFUSED 127.0.0.1:3001)*

