### PR TITLE
feat(map): add marker clustering

### DIFF
--- a/web/components/Map.tsx
+++ b/web/components/Map.tsx
@@ -1,25 +1,41 @@
 'use client';
 
+import React from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import type { LatLngExpression } from 'leaflet';
+import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import 'react-leaflet-cluster/dist/assets/MarkerCluster.css';
+import 'react-leaflet-cluster/dist/assets/MarkerCluster.Default.css';
+import MarkerClusterGroup from 'react-leaflet-cluster';
 import { Spot } from '../lib/types';
 
 export default function Map({ spots }: { spots: Spot[] }) {
   return (
     <MapContainer
       center={[-33.865143, 151.2099] as LatLngExpression}
-
       zoom={12}
       className="h-full"
     >
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
-      {spots.map((spot) => (
-        <Marker key={spot.id} position={[spot.lat, spot.lng] as LatLngExpression}>
-
-          <Popup>{spot.name}</Popup>
-        </Marker>
-      ))}
+      <MarkerClusterGroup
+        chunkedLoading
+        iconCreateFunction={(cluster) => {
+          const count = cluster.getChildCount();
+          const size = count < 10 ? 'small' : count < 100 ? 'medium' : 'large';
+          return L.divIcon({
+            html: `<span>${count}</span>`,
+            className: `marker-cluster marker-cluster-${size}`,
+          });
+        }}
+      >
+        {spots.map((spot) => (
+          <Marker key={spot.id} position={[spot.lat, spot.lng] as LatLngExpression}>
+            <Popup>{spot.name}</Popup>
+          </Marker>
+        ))}
+      </MarkerClusterGroup>
     </MapContainer>
   );
 }
+

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.29.0",
     "leaflet": "^1.9.4",
     "react-leaflet": "^4.2.1",
+    "react-leaflet-cluster": "^3.1.1",
     "next-auth": "^4.24.6",
     "jsonwebtoken": "^9.0.2"
   },

--- a/web/test/MapCluster.test.tsx
+++ b/web/test/MapCluster.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Map from '../components/Map';
+import { Spot } from '../lib/types';
+
+vi.mock('react-leaflet-cluster', () => {
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) => (
+      <div className="marker-cluster">{React.Children.count(children)}</div>
+    ),
+  };
+});
+
+describe('Map clustering', () => {
+  it('clusters nearby spots', () => {
+    const spots: Spot[] = [
+      { id: '1', name: 'One', lat: -33.865, lng: 151.209, description: '' },
+      { id: '2', name: 'Two', lat: -33.8651, lng: 151.2091, description: '' },
+    ];
+    const { container } = render(<Map spots={spots} />);
+    const cluster = container.querySelector('.marker-cluster');
+    expect(cluster?.textContent).toBe('2');
+  });
+});


### PR DESCRIPTION
## Summary
- add react-leaflet-cluster with custom styling to map
- wrap map markers in a cluster group
- test clustered marker rendering

## Testing
- `pnpm test test/MapCluster.test.tsx`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'url'))*

