### PR TITLE
Add S3 upload presign endpoint with tests

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -19,7 +19,9 @@
     "bcryptjs": "^2.4.3",
     "fastify": "^4.27.0",
     "fastify-type-provider-zod": "^2.0.0",
-    "zod": "^3.23.4"
+    "zod": "^3.23.4",
+    "@aws-sdk/client-s3": "^3.614.0",
+    "@aws-sdk/s3-request-presigner": "^3.614.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/api/test/spots.test.ts
+++ b/api/test/spots.test.ts
@@ -30,7 +30,7 @@ describe('spots CRUD', () => {
     const createRes = await app.inject({
       method: 'POST',
       url: '/spots',
-      payload: { name: 'My Spot', lat: 1, lng: 2 },
+      payload: { name: 'My Spot', lat: 1, lng: 2, category: 'park' },
       headers: { Authorization: `Bearer ${token}` },
     });
     expect(createRes.statusCode).toBe(200);

--- a/api/test/uploads.test.ts
+++ b/api/test/uploads.test.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildServer } from '../src/server';
+import { createPrismaMock } from './utils';
+
+vi.mock('@prisma/client', () => ({
+  PrismaClient: class {
+    constructor() {
+      return createPrismaMock();
+    }
+  },
+}));
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: vi.fn().mockResolvedValue('https://example.com/presigned'),
+}));
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: class {},
+  PutObjectCommand: class {
+    input: any;
+    constructor(input: any) {
+      this.input = input;
+    }
+  },
+}));
+
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+
+describe('uploads presign route', () => {
+  beforeEach(() => {
+    (getSignedUrl as any).mockClear();
+    process.env.S3_BUCKET = 'test-bucket';
+    process.env.S3_ENDPOINT = 'http://localhost:9000';
+    process.env.S3_ACCESS_KEY = 'key';
+    process.env.S3_SECRET_KEY = 'secret';
+  });
+
+  it('returns presigned url and key', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/uploads/presign',
+      payload: { filename: 'test.jpg', contentType: 'image/jpeg', size: 123 },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      url: 'https://example.com/presigned',
+      key: expect.stringMatching(/test.jpg$/),
+    });
+    expect(getSignedUrl).toHaveBeenCalledOnce();
+    const [, command] = (getSignedUrl as any).mock.calls[0];
+    expect(command.input.Bucket).toBe('test-bucket');
+    expect(command.input.Key).toMatch(/test.jpg$/);
+    expect(command.input.ContentType).toBe('image/jpeg');
+    expect(command.input.ContentLength).toBe(123);
+  });
+
+  it('validates request body', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/uploads/presign',
+      payload: { filename: 'onlyname' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/api/test/utils.ts
+++ b/api/test/utils.ts
@@ -11,7 +11,7 @@ export function createPrismaMock() {
   return {
     user: {
       async create({ data }: any) {
-        const user = { ...data, id: crypto.randomUUID() };
+        const user = { ...data, id: crypto.randomUUID(), emailVerified: true };
         users.set(user.id, user);
         return user;
       },
@@ -20,8 +20,8 @@ export function createPrismaMock() {
       },
     },
     async $executeRaw(_strings: TemplateStringsArray, ...values: any[]) {
-      const [id, name, description, lng, lat, userId] = values;
-      const spot = { id, name, description, lat, lng, userId };
+      const [id, name, description, lng, lat, facilities, category, isPublished, userId] = values;
+      const spot = { id, name, description, lat, lng, userId, facilities, category, isPublished };
       spots.set(id, spot);
       return 1;
     },


### PR DESCRIPTION
## Summary
- add `/uploads/presign` endpoint generating S3 presigned URLs
- add AWS SDK dependencies and update test utilities
- cover uploads presign flow with integration tests

## Testing
- `pnpm --filter api lint`
- `pnpm --filter api test`


------
https://chatgpt.com/codex/tasks/task_e_68c5ab3d0ce08329865eb8f0996a707a