### PR TITLE
Add route pages and builder with navigation links

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import { ReactNode } from 'react';
 import { Inter } from 'next/font/google';
+import Link from 'next/link';
 import QueryProvider from '../components/QueryProvider';
 import { SessionProvider } from 'next-auth/react';
 import AuthButton from '../components/AuthButton';
@@ -13,7 +14,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className={inter.className + ' min-h-screen flex flex-col'}>
         <SessionProvider>
           <QueryProvider>
-            <nav className="p-4 border-b flex justify-end">
+            <nav className="p-4 border-b flex justify-between items-center">
+              <div className="space-x-4">
+                <Link href="/">Home</Link>
+                <Link href="/routes">Routes</Link>
+                <Link href="/routes/new">New Route</Link>
+              </div>
               <AuthButton />
             </nav>
             <main className="flex-1">{children}</main>

--- a/web/app/routes/[id]/page.tsx
+++ b/web/app/routes/[id]/page.tsx
@@ -2,8 +2,8 @@
 
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { fetchRoute } from '../../../lib/api';
 import Map from '../../../components/Map';
+import { fetchRoute } from '../../../lib/api';
 
 export default function RoutePage() {
   const params = useParams();
@@ -26,6 +26,14 @@ export default function RoutePage() {
       </div>
       <div className="h-64">
         <Map spots={spots} />
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold">Spots</h2>
+        <ol className="list-decimal pl-5 space-y-1">
+          {data.spots.map((rs) => (
+            <li key={rs.spot.id}>{rs.spot.name}</li>
+          ))}
+        </ol>
       </div>
     </div>
   );

--- a/web/app/routes/new/page.tsx
+++ b/web/app/routes/new/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import Map from '../../../components/Map';
+import Button from '../../../components/ui/Button';
+import { fetchSpots, createRoute } from '../../../lib/api';
+import { Spot } from '../../../lib/types';
+
+export default function NewRoutePage() {
+  const [selected, setSelected] = useState<Spot[]>([]);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const { data: spots } = useQuery({ queryKey: ['spots'], queryFn: () => fetchSpots() });
+
+  const mutation = useMutation(createRoute, {
+    onSuccess: (route) => {
+      queryClient.invalidateQueries(['routes']);
+      queryClient.setQueryData(['route', route.id], route);
+      router.push(`/routes/${route.id}`);
+    },
+  });
+
+  const handleMarkerClick = (spot: Spot) => {
+    if (selected.some((s) => s.id === spot.id)) return;
+    setSelected((prev) => [...prev, spot]);
+  };
+
+  const removeSpot = (id: string) => {
+    setSelected((prev) => prev.filter((s) => s.id !== id));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (selected.length === 0) return;
+    mutation.mutate({ name, description, spotIds: selected.map((s) => s.id) });
+  };
+
+  if (!spots) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">New Route</h1>
+      <div className="h-64">
+        <Map spots={spots} onMarkerClick={handleMarkerClick} />
+      </div>
+      {selected.length > 0 && (
+        <ol className="list-decimal pl-5 space-y-1">
+          {selected.map((spot) => (
+            <li key={spot.id} className="flex justify-between items-center">
+              <span>{spot.name}</span>
+              <button
+                className="text-sm text-red-600"
+                onClick={() => removeSpot(spot.id)}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ol>
+      )}
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Route name"
+          required
+        />
+        <textarea
+          className="border p-2 w-full"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description"
+        />
+        <Button type="submit" disabled={mutation.isLoading || selected.length === 0}>
+          {mutation.isLoading ? 'Saving...' : 'Save Route'}
+        </Button>
+      </form>
+    </div>
+  );
+}
+

--- a/web/app/routes/page.tsx
+++ b/web/app/routes/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { fetchRoutes } from '../../lib/api';
+
+export default function RoutesPage() {
+  const { data } = useQuery({ queryKey: ['routes'], queryFn: fetchRoutes });
+
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Routes</h1>
+        <Link href="/routes/new" className="text-green-600">
+          New Route
+        </Link>
+      </div>
+      <ul className="list-disc pl-5 space-y-1">
+        {data.map((route) => (
+          <li key={route.id}>
+            <Link href={`/routes/${route.id}`}>{route.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/web/components/Map.tsx
+++ b/web/components/Map.tsx
@@ -10,7 +10,12 @@ import 'react-leaflet-cluster/dist/assets/MarkerCluster.Default.css';
 import MarkerClusterGroup from 'react-leaflet-cluster';
 import { Spot } from '../lib/types';
 
-export default function Map({ spots }: { spots: Spot[] }) {
+interface MapProps {
+  spots: Spot[];
+  onMarkerClick?: (spot: Spot) => void;
+}
+
+export default function Map({ spots, onMarkerClick }: MapProps) {
   return (
     <MapContainer
       center={[-33.865143, 151.2099] as LatLngExpression}
@@ -30,7 +35,17 @@ export default function Map({ spots }: { spots: Spot[] }) {
         }}
       >
         {spots.map((spot) => (
-          <Marker key={spot.id} position={[spot.lat, spot.lng] as LatLngExpression}>
+          <Marker
+            key={spot.id}
+            position={[spot.lat, spot.lng] as LatLngExpression}
+            eventHandlers={
+              onMarkerClick
+                ? {
+                    click: () => onMarkerClick(spot),
+                  }
+                : undefined
+            }
+          >
             <Popup>{spot.name}</Popup>
           </Marker>
         ))}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,4 +1,4 @@
-import { Spot, Report } from './types';
+import { Spot, Report, Route } from './types';
 
 
 export interface SpotFilters {
@@ -62,4 +62,32 @@ export async function addFavourite(spotId: string): Promise<Spot> {
 export async function removeFavourite(spotId: string): Promise<void> {
   const res = await fetch(`/api/me/favourites/${spotId}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to remove favourite');
+}
+
+export async function fetchRoutes(): Promise<Route[]> {
+  const res = await fetch('/api/routes');
+  if (!res.ok) throw new Error('Failed to fetch routes');
+  return res.json();
+}
+
+export async function fetchRoute(id: string): Promise<Route> {
+  const res = await fetch(`/api/routes/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch route');
+  return res.json();
+}
+
+export interface CreateRouteInput {
+  name: string;
+  description?: string;
+  spotIds: string[];
+}
+
+export async function createRoute(input: CreateRouteInput): Promise<Route> {
+  const res = await fetch('/api/routes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) throw new Error('Failed to create route');
+  return res.json();
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -6,6 +6,18 @@ export interface Spot {
   description: string;
 }
 
+export interface RouteSpot {
+  order: number;
+  spot: Spot;
+}
+
+export interface Route {
+  id: string;
+  name: string;
+  description?: string | null;
+  spots: RouteSpot[];
+}
+
 export interface Report {
   id: string;
   reason: string;


### PR DESCRIPTION
## Summary
- show individual routes with maps and ordered spot list
- create interactive route builder and route index
- expose route APIs and connect navigation

## Testing
- `pnpm lint`
- `pnpm typecheck` (fails: Property 'route' does not exist on type 'PrismaClient')
- `pnpm test` (fails: Cannot read properties of undefined (reading 'url'))
