### PR TITLE
Add category filtering for spots

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -259,12 +259,13 @@ export function buildServer() {
         bbox: z.string().optional(),
         radius: z.number().optional(),
         center: z.string().optional(),
+        category: z.enum(['park', 'garden', 'walk', 'lookout', 'playground', 'beach', 'other']).optional(),
         page: z.number().int().min(1).optional(),
         pageSize: z.number().int().min(1).max(100).optional(),
       }),
     },
   }, async (req) => {
-    const { q, tags, bbox, radius, center, page = 1, pageSize = 20 } = req.query;
+    const { q, tags, bbox, radius, center, category, page = 1, pageSize = 20 } = req.query;
     let ids: { id: string }[] | null = null;
 
     if (radius && center) {
@@ -282,6 +283,7 @@ export function buildServer() {
     const where: Record<string, unknown> = {};
     if (ids) where.id = { in: ids.map((r) => r.id) };
     if (q) where.name = { contains: q, mode: 'insensitive' };
+    if (category) where.category = category;
     if (tags) {
       const tagArr = tags.split(',');
       where.tags = { some: { tag: { name: { in: tagArr } } } };

--- a/web/app/api/spots/route.ts
+++ b/web/app/api/spots/route.ts
@@ -5,7 +5,7 @@ const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const params = new URLSearchParams();
-  for (const key of ['bbox', 'radius', 'tags', 'q']) {
+  for (const key of ['bbox', 'radius', 'tags', 'category']) {
     const value = url.searchParams.get(key);
     if (value) params.set(key, value);
   }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -21,7 +21,7 @@ export default function HomePage() {
         tags: filters.tags
           ? filters.tags.split(',').map((t) => t.trim()).filter(Boolean)
           : undefined,
-        q: filters.category || undefined,
+        category: filters.category || undefined,
       }),
   });
 

--- a/web/components/FilterBar.tsx
+++ b/web/components/FilterBar.tsx
@@ -29,7 +29,11 @@ export default function FilterBar({
         <option value="">All Categories</option>
         <option value="park">Park</option>
         <option value="garden">Garden</option>
-        <option value="community">Community</option>
+        <option value="walk">Walk</option>
+        <option value="lookout">Lookout</option>
+        <option value="playground">Playground</option>
+        <option value="beach">Beach</option>
+        <option value="other">Other</option>
       </select>
       <input
         type="text"

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -5,7 +5,7 @@ export interface SpotFilters {
   bbox?: string;
   radius?: number;
   tags?: string[];
-  q?: string;
+  category?: string;
 }
 
 export async function fetchSpots(filters: SpotFilters = {}): Promise<Spot[]> {
@@ -13,7 +13,7 @@ export async function fetchSpots(filters: SpotFilters = {}): Promise<Spot[]> {
   if (filters.bbox) params.set('bbox', filters.bbox);
   if (typeof filters.radius === 'number') params.set('radius', String(filters.radius));
   if (filters.tags && filters.tags.length > 0) params.set('tags', filters.tags.join(','));
-  if (filters.q) params.set('q', filters.q);
+  if (filters.category) params.set('category', filters.category);
 
   const query = params.toString();
   const res = await fetch(`/api/spots${query ? `?${query}` : ''}`);


### PR DESCRIPTION
## Summary
- expand FilterBar categories to include walk, lookout, playground, beach and other
- send selected category through web API and backend server
- allow backend /spots handler to filter by category

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'url'); expected 200 to be 401, etc.)*

