### PR TITLE
feat(api): secure auth cookies

### DIFF
--- a/api/test/auth.test.ts
+++ b/api/test/auth.test.ts
@@ -11,6 +11,10 @@ vi.mock('@prisma/client', () => ({
   }
 }));
 
+vi.mock('@fastify/redis', () => ({
+  default: (_f: any, _o: any, done: any) => done(),
+}));
+
 import { buildServer } from '../src/server';
 
 describe('auth routes', () => {
@@ -47,5 +51,42 @@ describe('auth routes', () => {
       payload: { email: 'test@example.com', password: 'wrong' },
     });
     expect(res.statusCode).toBe(401);
+  });
+
+  it('sets secure cookie attributes in production', async () => {
+    const oldNodeEnv = process.env.NODE_ENV;
+    const oldCookieSecure = process.env.COOKIE_SECURE;
+    const oldCookieDomain = process.env.COOKIE_DOMAIN;
+    process.env.NODE_ENV = 'production';
+    process.env.COOKIE_SECURE = 'true';
+    process.env.COOKIE_DOMAIN = 'example.com';
+
+    const app = buildServer();
+
+    const hash = await bcrypt.hash('secret123', 10);
+    await (app as any).prisma.user.create({
+      data: { email: 'test@example.com', passwordHash: hash, emailVerified: true },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/login',
+      payload: { email: 'test@example.com', password: 'secret123' },
+    });
+    expect(res.statusCode).toBe(200);
+    const cookie = res.cookies.find((c: any) => c.name === 'token');
+    expect(cookie).toBeTruthy();
+    const c = cookie!;
+    expect(c.httpOnly).toBe(true);
+    expect(c.secure).toBe(true);
+    expect(String(c.sameSite).toLowerCase()).toBe('strict');
+    expect(c.path).toBe('/');
+    expect(c.domain).toBe('example.com');
+
+    process.env.NODE_ENV = oldNodeEnv;
+    if (oldCookieSecure === undefined) delete process.env.COOKIE_SECURE;
+    else process.env.COOKIE_SECURE = oldCookieSecure;
+    if (oldCookieDomain === undefined) delete process.env.COOKIE_DOMAIN;
+    else process.env.COOKIE_DOMAIN = oldCookieDomain;
   });
 });

--- a/api/test/spots.test.ts
+++ b/api/test/spots.test.ts
@@ -30,7 +30,7 @@ describe('spots CRUD', () => {
     const createRes = await app.inject({
       method: 'POST',
       url: '/spots',
-      payload: { name: 'My Spot', lat: 1, lng: 2 },
+      payload: { name: 'My Spot', lat: 1, lng: 2, category: 'park' },
       headers: { Authorization: `Bearer ${token}` },
     });
     expect(createRes.statusCode).toBe(200);

--- a/api/test/utils.ts
+++ b/api/test/utils.ts
@@ -11,7 +11,7 @@ export function createPrismaMock() {
   return {
     user: {
       async create({ data }: any) {
-        const user = { ...data, id: crypto.randomUUID() };
+        const user = { emailVerified: true, ...data, id: crypto.randomUUID() };
         users.set(user.id, user);
         return user;
       },
@@ -20,7 +20,7 @@ export function createPrismaMock() {
       },
     },
     async $executeRaw(_strings: TemplateStringsArray, ...values: any[]) {
-      const [id, name, description, lng, lat, userId] = values;
+      const [id, name, description, lng, lat, _facilities, _category, _isPublished, userId] = values;
       const spot = { id, name, description, lat, lng, userId };
       spots.set(id, spot);
       return 1;


### PR DESCRIPTION
## Summary
- set auth cookies with secure defaults and allow configuring via COOKIE_SECURE and COOKIE_DOMAIN
- mock redis and add tests verifying secure cookie attributes in production
- adjust test utilities for verified users and spot creation

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Property 'route' does not exist on type 'PrismaClient')*
- `pnpm test`


