### PR TITLE
feat: add analytics and error monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 # Example environment variables for local development
 NEXT_PUBLIC_API_URL=http://localhost:3001
+# Set to enable Plausible analytics; leave blank to disable
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN=
+SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_DSN=

--- a/api/package.json
+++ b/api/package.json
@@ -19,7 +19,8 @@
     "bcryptjs": "^2.4.3",
     "fastify": "^4.27.0",
     "fastify-type-provider-zod": "^2.0.0",
-    "zod": "^3.23.4"
+    "zod": "^3.23.4",
+    "@sentry/node": "^10.11.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,4 +1,5 @@
 import Fastify, { FastifyReply, FastifyRequest } from 'fastify';
+import * as Sentry from '@sentry/node';
 import fastifyJwt from '@fastify/jwt';
 import fastifyRedis from '@fastify/redis';
 import fastifyCookie from '@fastify/cookie';
@@ -16,7 +17,19 @@ type RedisClient = {
 };
 
 export function buildServer() {
+  const enableSentry = !!process.env.SENTRY_DSN;
+  if (enableSentry) {
+    Sentry.init({ dsn: process.env.SENTRY_DSN });
+  }
+
   const app = Fastify().withTypeProvider<ZodTypeProvider>();
+
+  app.setErrorHandler((error, request, reply) => {
+    if (enableSentry) {
+      Sentry.captureException(error);
+    }
+    reply.send(error);
+  });
 
   app.setValidatorCompiler(validatorCompiler);
   app.setSerializerCompiler(serializerCompiler);

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,16 +1,27 @@
 import './globals.css';
 import { ReactNode } from 'react';
 import { Inter } from 'next/font/google';
+import Script from 'next/script';
 import QueryProvider from '../components/QueryProvider';
 import { SessionProvider } from 'next-auth/react';
 import AuthButton from '../components/AuthButton';
+import '../lib/sentry';
 
 const inter = Inter({ subsets: ['latin'] });
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const plausibleDomain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+
   return (
     <html lang="en">
       <body className={inter.className + ' min-h-screen flex flex-col'}>
+        {plausibleDomain && (
+          <Script
+            src={`https://${plausibleDomain}/js/script.js`}
+            data-domain={plausibleDomain}
+            strategy="afterInteractive"
+          />
+        )}
         <SessionProvider>
           <QueryProvider>
             <nav className="p-4 border-b flex justify-end">

--- a/web/lib/sentry.ts
+++ b/web/lib/sentry.ts
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/browser';
+
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+if (dsn) {
+  Sentry.init({ dsn });
+}
+
+export default Sentry;

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,8 @@
     "react-leaflet": "^4.2.1",
     "react-leaflet-cluster": "^3.1.1",
     "next-auth": "^4.24.6",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "@sentry/browser": "^10.11.0"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",


### PR DESCRIPTION
## Summary
- load Plausible analytics script when `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` is set
- initialize Sentry on server and client for error logging
- document env vars for analytics and Sentry

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Property 'route' does not exist on type 'PrismaClient')*
- `pnpm test` *(fails: auth routes and spots CRUD tests)*

