### PR TITLE
Add geolocation control and forward user position to API

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import { ReactNode } from 'react';
 import { Inter } from 'next/font/google';
+import Link from 'next/link';
 import Script from 'next/script';
 
 import QueryProvider from '../components/QueryProvider';

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -12,12 +12,14 @@ export default function HomePage() {
     tags: '',
     radius: 1000,
   });
+  const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
 
   const { data } = useQuery({
-    queryKey: ['spots', filters],
+    queryKey: ['spots', filters, userLocation],
     queryFn: () =>
       fetchSpots({
         radius: filters.radius,
+        center: userLocation ? `${userLocation.lng},${userLocation.lat}` : undefined,
         tags: filters.tags
           ? filters.tags.split(',').map((t) => t.trim()).filter(Boolean)
           : undefined,
@@ -31,7 +33,7 @@ export default function HomePage() {
     <div className="h-full flex flex-col">
       <FilterBar filters={filters} onChange={setFilters} />
       <div className="flex-1">
-        <Map spots={data} />
+        <Map spots={data} onLocation={setUserLocation} />
       </div>
     </div>
   );

--- a/web/components/Map.tsx
+++ b/web/components/Map.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import type { LatLngExpression } from 'leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -13,9 +13,44 @@ import { Spot } from '../lib/types';
 interface MapProps {
   spots: Spot[];
   onMarkerClick?: (spot: Spot) => void;
+  onLocation?: (coords: { lat: number; lng: number }) => void;
 }
 
-export default function Map({ spots, onMarkerClick }: MapProps) {
+function LocateControl({
+  onLocate,
+}: {
+  onLocate?: (coords: { lat: number; lng: number }) => void;
+}) {
+  const map = useMap();
+
+  React.useEffect(() => {
+    const control = new L.Control({ position: 'topleft' });
+    control.onAdd = () => {
+      const button = L.DomUtil.create('button', 'leaflet-bar');
+      button.type = 'button';
+      button.title = 'Use my location';
+      button.innerHTML = '📍';
+      L.DomEvent.on(button, 'click', () => {
+        if (navigator.geolocation) {
+          navigator.geolocation.getCurrentPosition((pos) => {
+            const { latitude, longitude } = pos.coords;
+            map.setView([latitude, longitude]);
+            onLocate?.({ lat: latitude, lng: longitude });
+          });
+        }
+      });
+      return button;
+    };
+    control.addTo(map);
+    return () => {
+      control.remove();
+    };
+  }, [map, onLocate]);
+
+  return null;
+}
+
+export default function Map({ spots, onMarkerClick, onLocation }: MapProps) {
   return (
     <MapContainer
       center={[-33.865143, 151.2099] as LatLngExpression}
@@ -23,9 +58,10 @@ export default function Map({ spots, onMarkerClick }: MapProps) {
       className="h-full"
     >
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+      <LocateControl onLocate={onLocation} />
       <MarkerClusterGroup
         chunkedLoading
-        iconCreateFunction={(cluster) => {
+        iconCreateFunction={(cluster: any) => {
           const count = cluster.getChildCount();
           const size = count < 10 ? 'small' : count < 100 ? 'medium' : 'large';
           return L.divIcon({

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -3,6 +3,7 @@ import { Spot, Report, Route } from './types';
 
 export interface SpotFilters {
   bbox?: string;
+  center?: string;
   radius?: number;
   tags?: string[];
   category?: string;
@@ -11,6 +12,7 @@ export interface SpotFilters {
 export async function fetchSpots(filters: SpotFilters = {}): Promise<Spot[]> {
   const params = new URLSearchParams();
   if (filters.bbox) params.set('bbox', filters.bbox);
+  if (filters.center) params.set('center', filters.center);
   if (typeof filters.radius === 'number') params.set('radius', String(filters.radius));
   if (filters.tags && filters.tags.length > 0) params.set('tags', filters.tags.join(','));
   if (filters.category) params.set('category', filters.category);


### PR DESCRIPTION
## Summary
- add locate control on the map to recenter using browser geolocation
- emit user position to parent and include center in spot queries
- fix missing Link import in layout for lint

## Testing
- `pnpm lint`
- `pnpm test` (fails: @sentry/node module missing)
- `pnpm typecheck` (fails: cannot find modules such as @sentry/node)


