### PR TITLE
feat: add analytics toggle and Sentry config

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -20,7 +20,8 @@ type RedisClient = {
 };
 
 export function buildServer() {
-  const enableSentry = !!process.env.SENTRY_DSN;
+  const enableSentry =
+    !!process.env.SENTRY_DSN && process.env.DISABLE_ANALYTICS !== 'true';
   if (enableSentry) {
     Sentry.init({ dsn: process.env.SENTRY_DSN });
   }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import { ReactNode } from 'react';
 import { Inter } from 'next/font/google';
 import Script from 'next/script';
+import Link from 'next/link';
 
 import QueryProvider from '../components/QueryProvider';
 import { SessionProvider } from 'next-auth/react';
@@ -11,12 +12,14 @@ import '../lib/sentry';
 const inter = Inter({ subsets: ['latin'] });
 
 export default function RootLayout({ children }: { children: ReactNode }) {
-  const plausibleDomain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+  const plausibleDomain = process.env.PLAUSIBLE_DOMAIN;
+  const analyticsDisabled =
+    process.env.NEXT_PUBLIC_DISABLE_ANALYTICS === 'true';
 
   return (
     <html lang="en">
       <body className={inter.className + ' min-h-screen flex flex-col'}>
-        {plausibleDomain && (
+        {plausibleDomain && !analyticsDisabled && (
           <Script
             src={`https://${plausibleDomain}/js/script.js`}
             data-domain={plausibleDomain}

--- a/web/lib/sentry.ts
+++ b/web/lib/sentry.ts
@@ -1,8 +1,10 @@
 import * as Sentry from '@sentry/browser';
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const analyticsDisabled =
+  process.env.NEXT_PUBLIC_DISABLE_ANALYTICS === 'true';
 
-if (dsn) {
+if (dsn && !analyticsDisabled) {
   Sentry.init({ dsn });
 }
 


### PR DESCRIPTION
## Summary
- add Plausible script keyed by `PLAUSIBLE_DOMAIN` with ability to disable via env flag
- gate Sentry client initialization with analytics toggle
- allow backend Sentry to be disabled with `DISABLE_ANALYTICS`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find module '@sentry/node' or '@aws-sdk/client-s3', Prisma `route` property missing)*
- `pnpm test` *(fails: Failed to load url @sentry/node in api/src/server.ts)*
