### PR TITLE
Render spot facilities and photos

### DIFF
--- a/web/app/spots/[id]/page.tsx
+++ b/web/app/spots/[id]/page.tsx
@@ -1,8 +1,17 @@
 'use client';
 
+import React from 'react';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { fetchSpot } from '../../../lib/api';
+
+const facilityIcons: Record<string, string> = {
+  toilets: '🚽',
+  water: '🚰',
+  bbq: '🍖',
+  picnic: '🧺',
+  playground: '🛝',
+};
 
 export default function SpotPage() {
   const params = useParams();
@@ -10,9 +19,42 @@ export default function SpotPage() {
   const { data } = useQuery({ queryKey: ['spot', id], queryFn: () => fetchSpot(id), enabled: !!id });
   if (!data) return <div className="p-4">Loading...</div>;
   return (
-    <div className="p-4 space-y-2">
+    <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">{data.name}</h1>
       <p>{data.description}</p>
+      {data.photos && data.photos.length > 0 && (
+        <div className="grid grid-cols-2 gap-2">
+          {data.photos.map((photo, i) => (
+            <img
+              key={photo.id}
+              src={photo.url}
+              alt={`${data.name} photo ${i + 1}`}
+              className="w-full h-40 object-cover rounded"
+            />
+          ))}
+        </div>
+      )}
+      {data.facilities && (
+        <div className="flex gap-2">
+          {Object.entries(data.facilities).map(([key, value]) =>
+            value ? (
+              <span key={key} title={key} className="text-xl">
+                {facilityIcons[key] ?? '✅'}
+              </span>
+            ) : null
+          )}
+        </div>
+      )}
+      {data.tags && data.tags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {data.tags.map((tag) => (
+            <span key={tag.id} className="bg-gray-200 px-2 py-1 rounded text-sm">
+              {tag.name}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="font-semibold">Score: {data.voteScore ?? 0}</div>
     </div>
   );
 }

--- a/web/components/Map.tsx
+++ b/web/components/Map.tsx
@@ -61,6 +61,7 @@ export default function Map({ spots, onMarkerClick, onLocation }: MapProps) {
       <LocateControl onLocate={onLocation} />
       <MarkerClusterGroup
         chunkedLoading
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         iconCreateFunction={(cluster: any) => {
           const count = cluster.getChildCount();
           const size = count < 10 ? 'small' : count < 100 ? 'medium' : 'large';

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -28,7 +28,24 @@ export async function fetchSpots(filters: SpotFilters = {}): Promise<Spot[]> {
 export async function fetchSpot(id: string): Promise<Spot> {
   const res = await fetch(`/api/spots/${id}`);
   if (!res.ok) throw new Error('Failed to fetch spot');
-  return res.json();
+  const data = await res.json();
+  return {
+    ...data,
+    facilities: data.facilities ?? {},
+    photos: data.photos ?? [],
+    tags: data.tags
+      ? data.tags.map(
+          (
+            t: {
+              tag?: { id: string; name: string };
+              id: string;
+              name?: string;
+            }
+          ) => (t.tag ? { id: t.tag.id, name: t.tag.name } : { id: t.id, name: t.name || '' })
+        )
+      : [],
+    voteScore: data.voteScore ?? data.score ?? 0,
+  };
 }
 
 export async function fetchModerationQueue(): Promise<Report[]> {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1,9 +1,23 @@
+export interface SpotPhoto {
+  id: string;
+  url: string;
+}
+
+export interface SpotTag {
+  id: string;
+  name: string;
+}
+
 export interface Spot {
   id: string;
   name: string;
   lat: number;
   lng: number;
   description: string;
+  facilities?: Record<string, boolean>;
+  photos?: SpotPhoto[];
+  tags?: SpotTag[];
+  voteScore?: number;
 }
 
 export interface RouteSpot {

--- a/web/test/SpotPage.test.tsx
+++ b/web/test/SpotPage.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, type Mock } from 'vitest';
+import SpotPage from '../app/spots/[id]/page';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fetchSpot } from '../lib/api';
+import type { Spot } from '../lib/types';
+
+vi.mock('next/navigation', () => ({ useParams: () => ({ id: '1' }) }));
+vi.mock('../lib/api', () => ({ fetchSpot: vi.fn() }));
+
+describe('SpotPage', () => {
+  it('renders facilities and photos when present', async () => {
+    const mockSpot: Spot = {
+      id: '1',
+      name: 'Test Spot',
+      lat: 0,
+      lng: 0,
+      description: 'desc',
+      facilities: { toilets: true },
+      photos: [{ id: 'p1', url: 'http://example.com/p1.jpg' }],
+      tags: [],
+      voteScore: 3,
+    };
+    (fetchSpot as unknown as Mock).mockResolvedValue(mockSpot);
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <SpotPage />
+      </QueryClientProvider>
+    );
+    await screen.findByText('Test Spot');
+    expect(screen.getByTitle('toilets')).toBeTruthy();
+    expect(screen.getByAltText('Test Spot photo 1')).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend API and types so `fetchSpot` returns facilities, photos, tags and vote score
- render photo gallery, facility icons, tags and score on spot page
- add component test verifying facilities and photos appear

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot read properties of undefined, failed to load @aws-sdk/client-s3)*
- `pnpm --filter web test test/SpotPage.test.tsx`


