### PR TITLE
Add spot reporting form and API proxy

### DIFF
--- a/web/app/api/reports/route.ts
+++ b/web/app/api/reports/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const res = await fetch(`${apiBase}/reports`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/web/app/spots/[id]/page.tsx
+++ b/web/app/spots/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { fetchSpot } from '../../../lib/api';
@@ -55,6 +56,12 @@ export default function SpotPage() {
         </div>
       )}
       <div className="font-semibold">Score: {data.voteScore ?? 0}</div>
+      <Link
+        href={`/spots/${id}/report`}
+        className="inline-block bg-red-500 text-white px-4 py-2 rounded"
+      >
+        Report
+      </Link>
     </div>
   );
 }

--- a/web/app/spots/[id]/report/page.tsx
+++ b/web/app/spots/[id]/report/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+
+export default function ReportSpotPage() {
+  const { id } = useParams();
+  const router = useRouter();
+  const [reason, setReason] = useState('');
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    await fetch('/api/reports', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ spotId: id as string, reason }),
+    });
+    router.push(`/spots/${id}`);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-4">
+      <textarea
+        className="w-full border p-2"
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        placeholder="Reason for report"
+      />
+      <button
+        type="submit"
+        className="bg-red-500 text-white px-4 py-2 rounded"
+      >
+        Submit Report
+      </button>
+    </form>
+  );
+}

--- a/web/test/ReportPage.test.tsx
+++ b/web/test/ReportPage.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import ReportSpotPage from '../app/spots/[id]/report/page';
+
+const originalFetch = global.fetch;
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: '1' }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('ReportSpotPage', () => {
+  it('submits report to api', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    render(<ReportSpotPage />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Bad spot' } });
+    fireEvent.click(screen.getByText('Submit Report'));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith('/api/reports', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ spotId: '1', reason: 'Bad spot' }),
+    }));
+  });
+});

--- a/web/test/SpotPage.test.tsx
+++ b/web/test/SpotPage.test.tsx
@@ -7,6 +7,9 @@ import { fetchSpot } from '../lib/api';
 import type { Spot } from '../lib/types';
 
 vi.mock('next/navigation', () => ({ useParams: () => ({ id: '1' }) }));
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
 vi.mock('../lib/api', () => ({ fetchSpot: vi.fn() }));
 
 describe('SpotPage', () => {
@@ -32,6 +35,7 @@ describe('SpotPage', () => {
     await screen.findByText('Test Spot');
     expect(screen.getByTitle('toilets')).toBeTruthy();
     expect(screen.getByAltText('Test Spot photo 1')).toBeTruthy();
+    expect(screen.getByText('Report').getAttribute('href')).toBe('/spots/1/report');
   });
 });
 

--- a/web/test/apiRoutes.test.ts
+++ b/web/test/apiRoutes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { GET as listSpots } from '../app/api/spots/route';
 import { GET as getSpot } from '../app/api/spots/[id]/route';
+import { POST as submitReport } from '../app/api/reports/route';
 
 const apiBase = 'http://localhost:3001';
 const originalFetch = global.fetch;
@@ -74,5 +75,30 @@ describe('spots API routes', () => {
       center: '6,7',
     }).toString();
     expect(fetchMock).toHaveBeenCalledWith(`${apiBase}/spots?${expected}`);
+  });
+});
+
+describe('reports API route', () => {
+  it('submits a report', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({ id: 'r1' }),
+      status: 200,
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const req = new Request('http://example.com', {
+      method: 'POST',
+      body: JSON.stringify({ spotId: '1', reason: 'Bad spot' }),
+    });
+
+    const res = await submitReport(req);
+    await res.json();
+
+    expect(fetchMock).toHaveBeenCalledWith(`${apiBase}/reports`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ spotId: '1', reason: 'Bad spot' }),
+    });
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
- add report button on spot page linking to a report form
- implement report submission form posting to `/api/reports`
- proxy POST `/api/reports` to Fastify backend
- test report form, API route, and link

## Testing
- `pnpm --filter web test`

