### PR TITLE
Add sitemap and robots metadata routes with tests

### DIFF
--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [
+        '/api',
+        '/login',
+        '/register',
+        '/me',
+        '/submit',
+        '/moderation',
+        '/request-password-reset',
+        '/reset-password',
+        '/verify-email',
+      ],
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}
+

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from 'next';
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const urls: MetadataRoute.Sitemap = [{ url: siteUrl }];
+
+  try {
+    const [routesRes, spotsRes] = await Promise.all([
+      fetch(`${apiBase}/routes`),
+      fetch(`${apiBase}/spots`),
+    ]);
+
+    if (routesRes.ok) {
+      const routes: { id: string }[] = await routesRes.json();
+      urls.push(
+        ...routes.map((r) => ({ url: `${siteUrl}/routes/${r.id}` }))
+      );
+    }
+
+    if (spotsRes.ok) {
+      const spots: { id: string }[] = await spotsRes.json();
+      urls.push(
+        ...spots.map((s) => ({ url: `${siteUrl}/spots/${s.id}` }))
+      );
+    }
+  } catch {
+    // ignore errors and return what we have
+  }
+
+  return urls;
+}
+

--- a/web/test/metadataRoutes.test.ts
+++ b/web/test/metadataRoutes.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { MetadataRoute } from 'next';
+import sitemap from '../app/sitemap';
+import robots from '../app/robots';
+
+const apiBase = 'http://localhost:3001';
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function sitemapToXml(entries: MetadataRoute.Sitemap): string {
+  const body = entries
+    .map((u) => `  <url><loc>${u.url}</loc></url>`)
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${body}\n</urlset>`;
+}
+
+describe('sitemap metadata route', () => {
+  it('lists routes and spots', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue([{ id: 'r1' }]) })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue([{ id: 's1' }]) });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const xml = sitemapToXml(await sitemap());
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, `${apiBase}/routes`);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, `${apiBase}/spots`);
+    expect(xml).toContain('<loc>http://localhost:3000/routes/r1</loc>');
+    expect(xml).toContain('<loc>http://localhost:3000/spots/s1</loc>');
+  });
+});
+
+function robotsToText(data: MetadataRoute.Robots): string {
+  const rules = Array.isArray(data.rules) ? data.rules : [data.rules];
+  const lines: string[] = [];
+  for (const rule of rules) {
+    lines.push(`User-agent: ${rule.userAgent}`);
+    const allow = Array.isArray(rule.allow) ? rule.allow : rule.allow ? [rule.allow] : [];
+    const disallow = Array.isArray(rule.disallow) ? rule.disallow : rule.disallow ? [rule.disallow] : [];
+    allow.forEach((a) => lines.push(`Allow: ${a}`));
+    disallow.forEach((d) => lines.push(`Disallow: ${d}`));
+  }
+  if (data.sitemap) lines.push(`Sitemap: ${data.sitemap}`);
+  return lines.join('\n');
+}
+
+describe('robots metadata route', () => {
+  it('blocks unwanted paths and sets sitemap', () => {
+    const text = robotsToText(robots());
+    expect(text).toContain('Disallow: /login');
+    expect(text).toContain('Disallow: /register');
+    expect(text).toContain('Sitemap: http://localhost:3000/sitemap.xml');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Next.js metadata routes for sitemap and robots
- list routes and spots in sitemap
- block sensitive paths in robots.txt
- cover endpoints with unit tests

## Testing
- `pnpm --filter web test`


------
https://chatgpt.com/codex/tasks/task_e_68c6a33a6314832989603aaf6087d3a4