### PR TITLE
feat: enable PWA with offline map tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 27. Appendix: Sample SQL & Queries
 28. Appendix: Wireframes (text) & Component Inventory
 29. Appendix: Sample Seed Data (Sydney spots)
+30. PWA Installation & Offline Use
 
 ---
 
@@ -764,4 +765,14 @@ WHERE id = $1;
    * *Note:* Expansive lawns; off‑leash areas popular in late arvo.
    * Facilities: toilets ✅, water ✅, dog‑friendly ✅
    * Tags: dog, spacious, heritage
+
+---
+
+## 30) PWA Installation & Offline Use
+
+The app can be installed on modern browsers and continues to work with limited connectivity:
+
+* **Installation** – When viewing the site, use the browser's install prompt or "Add to Home Screen" option to install it as a standalone app.
+* **Offline behaviour** – Static assets and any OpenStreetMap tiles you've already viewed are cached for reuse. After exploring an area of the map, those tiles remain available even without a network connection.
+* **Limitations** – New map areas and fresh data still require an internet connection.
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,11 +3,11 @@ import { ReactNode } from 'react';
 import { Inter } from 'next/font/google';
 import Link from 'next/link';
 import Script from 'next/script';
-import Link from 'next/link';
 
 import QueryProvider from '../components/QueryProvider';
 import { SessionProvider } from 'next-auth/react';
 import AuthButton from '../components/AuthButton';
+import Pwa from '../components/Pwa';
 import '../lib/sentry';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -19,6 +19,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 
   return (
     <html lang="en">
+      <head>
+        <link rel="manifest" href="/manifest.json" />
+      </head>
       <body className={inter.className + ' min-h-screen flex flex-col'}>
         {plausibleDomain && !analyticsDisabled && (
           <Script
@@ -40,6 +43,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <main className="flex-1">{children}</main>
           </QueryProvider>
         </SessionProvider>
+        <Pwa />
       </body>
     </html>
   );

--- a/web/components/Pwa.tsx
+++ b/web/components/Pwa.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import 'next-pwa/register';
+
+export default function Pwa() {
+  return null;
+}

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,6 +1,41 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const withPWA = require('next-pwa')({
+  dest: 'public',
+  register: true,
+  skipWaiting: true,
+  runtimeCaching: [
+    {
+      urlPattern: /^https:\/\/.*\.tile\.openstreetmap\.org\/.*$/i,
+      handler: 'CacheFirst',
+      options: {
+        cacheName: 'osm-tiles',
+        expiration: {
+          maxEntries: 200,
+          maxAgeSeconds: 7 * 24 * 60 * 60, // 1 week
+        },
+        cacheableResponse: {
+          statuses: [0, 200],
+        },
+      },
+    },
+    {
+      urlPattern: ({ request }) =>
+        ['style', 'script', 'image'].includes(request.destination),
+      handler: 'StaleWhileRevalidate',
+      options: {
+        cacheName: 'static-resources',
+        expiration: {
+          maxEntries: 100,
+          maxAgeSeconds: 24 * 60 * 60,
+        },
+      },
+    },
+  ],
+});
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
 };
 
-module.exports = nextConfig;
+module.exports = withPWA(nextConfig);

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,8 @@
     "react-leaflet-cluster": "^3.1.1",
     "next-auth": "^4.24.6",
     "jsonwebtoken": "^9.0.2",
-    "@sentry/browser": "^10.11.0"
+    "@sentry/browser": "^10.11.0",
+    "next-pwa": "^5.6.0"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",

--- a/web/public/icons/icon.svg
+++ b/web/public/icons/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#006400"/>
+  <circle cx="256" cy="256" r="180" fill="#ffffff"/>
+</svg>

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Neighbourhood Green Map",
+  "short_name": "GreenMap",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#22c55e",
+  "icons": [
+    {
+      "src": "/icons/icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icons/icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/web/test/SpotPage.test.tsx
+++ b/web/test/SpotPage.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type ComponentProps } from 'react';
 import { render, screen } from '@testing-library/react';
 import { vi, describe, it, expect, type Mock } from 'vitest';
 import SpotPage from '../app/spots/[id]/page';
@@ -8,7 +8,9 @@ import type { Spot } from '../lib/types';
 
 vi.mock('next/navigation', () => ({ useParams: () => ({ id: '1' }) }));
 vi.mock('next/link', () => ({
-  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+  default: ({ children, ...props }: ComponentProps<'a'>) => (
+    <a {...props}>{children}</a>
+  ),
 }));
 vi.mock('../lib/api', () => ({ fetchSpot: vi.fn() }));
 

--- a/web/test/SubmitPage.test.tsx
+++ b/web/test/SubmitPage.test.tsx
@@ -1,17 +1,16 @@
-import React from 'react';
+import React, { type ComponentProps } from 'react';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import SubmitPage from '../app/submit/page';
 
-vi.mock('react-leaflet', () => {
-  const React = require('react');
-  return {
-    MapContainer: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    TileLayer: () => <div />,
-    Marker: () => <div />,
-    useMapEvents: () => {},
-  };
-});
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children, ...props }: ComponentProps<'div'>) => (
+    <div {...props}>{children}</div>
+  ),
+  TileLayer: () => <div />,
+  Marker: () => <div />,
+  useMapEvents: () => {},
+}));
 
 describe('SubmitPage', () => {
   const originalFetch = global.fetch;


### PR DESCRIPTION
## Summary
- add web app manifest and icons, referenced in layout
- enable next-pwa service worker to cache static assets and OpenStreetMap tiles
- document installation and offline usage in README
- replace `any` in test mocks with typed component props to satisfy lint
- switch to SVG PWA icon to avoid binary files

## Testing
- `pnpm -F web lint`
- `pnpm -F web test`


